### PR TITLE
Setup SQLAlchemy and session configuration; Add ExamSubscription component

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -13,6 +13,9 @@ pyramid.debug_routematch = false
 pyramid.default_locale_name = en
 pyramid.includes =
     pyramid_debugtoolbar
+    pyramid_tm
+
+sqlalchemy.url = mysql+pymysql://w4ladba:crisis@localhost/work4la
 
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.
@@ -43,6 +46,11 @@ keys = generic
 [logger_root]
 level = INFO
 handlers = console
+
+[logger_sqlalchemy]
+level = INFO
+handlers =
+qualname = sqlalchemy.engine
 
 [logger_work4la]
 level = DEBUG

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,20 +13,25 @@ PasteDeploy==1.5.2
 peppercorn==0.5
 py==1.4.33
 Pygments==2.2.0
+PyMySQL==0.7.11
 pyparsing==2.2.0
 pyramid==1.8.3
 pyramid-debugtoolbar==4.0
 pyramid-jinja2==2.7
 pyramid-mako==1.0.2
+pyramid-tm==2.1
 pytest==3.0.7
 pytest-cov==2.4.0
 repoze.lru==0.6
 six==1.10.0
+SQLAlchemy==1.1.11
+transaction==2.1.2
 translationstring==1.3
 venusian==1.1.0
 waitress==1.0.2
 WebOb==1.7.2
 WebTest==2.0.27
--e git+git@github.com:alexchao/work4la.git@d7fadbe28b4f65bee72c34edfcdbd5139f4bf515#egg=work4la
+-e git+git@github.com:alexchao/work4la.git@c63a9e13f2c6b939513e5f9e9cb46d6e0cc740d3#egg=work4la
 zope.deprecation==4.2.0
 zope.interface==4.4.0
+zope.sqlalchemy==0.7.7

--- a/work4la/__init__.py
+++ b/work4la/__init__.py
@@ -1,9 +1,16 @@
 from pyramid.config import Configurator
+from sqlalchemy import engine_from_config
+
+from work4la.models import DBSession
 
 
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
+    # sqlalchemy
+    engine = engine_from_config(settings, 'sqlalchemy.')
+    DBSession.configure(bind=engine)
+
     config = Configurator(settings=settings)
     config.include('pyramid_jinja2')
     config.add_static_view('static', 'static', cache_max_age=3600)

--- a/work4la/components/exam_subscription.py
+++ b/work4la/components/exam_subscription.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from collections import namedtuple
+
+from work4la.models import DBSession
+from work4la.models import ExamSubscriptionModel
+
+
+class ExamSubscription(namedtuple('ExamSubscription',
+                                  ['id', 'time_created',
+                                   'time_sent', 'email_address',
+                                   'job_id'])):
+
+    @classmethod
+    def from_model(cls, model):
+        return cls(model.id, model.time_created, model.time_sent,
+                   model.email_address, model.job_id)
+
+
+def make_new(email_address, job_id):
+    """Record a new subscription for exam notifications.
+
+    email_address -- user's email address
+    job_id -- ID of job class (not class_code or classspec_id)
+    """
+    new_subscription = ExamSubscriptionModel(
+        email_address=email_address,
+        job_id=job_id)
+    DBSession.add(new_subscription)
+    DBSession.flush()
+    return ExamSubscription.from_model(new_subscription)

--- a/work4la/models.py
+++ b/work4la/models.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import Integer
+from sqlalchemy import Text
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session
+from sqlalchemy.orm import sessionmaker
+from zope.sqlalchemy import ZopeTransactionExtension
+
+
+DBSession = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
+Base = declarative_base()
+
+
+class ExamSubscriptionModel(Base):
+
+    __tablename__ = 'exam_subscription'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    time_created = Column(DateTime)
+    time_sent = Column(DateTime)
+    email_address = Column(Text)
+    job_id = Column(Integer)

--- a/work4la/resources/schemas/exam_subscription.sql
+++ b/work4la/resources/schemas/exam_subscription.sql
@@ -1,0 +1,9 @@
+CREATE TABLE exam_subscription (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `time_created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `time_sent` TIMESTAMP NULL DEFAULT NULL,
+  `email_address` VARCHAR(254) NOT NULL,
+  `job_id` INT(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX job_id_idx (`job_id`)
+) ENGINE=InnoDB;

--- a/work4la/test/components/exam_subscription_test.py
+++ b/work4la/test/components/exam_subscription_test.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from sqlalchemy import create_engine
+
+from work4la.components import exam_subscription
+from work4la.models import ExamSubscriptionModel
+from work4la.models import DBSession
+from work4la.test.util.db import TEST_DB_URL
+
+
+
+class ExamSubscriptionTestCase(unittest.TestCase):
+
+    # TODO: move database configuration and helpers someplace
+    # sharable so this file has no DB-related imports
+    @classmethod
+    def setUpClass(cls):
+        engine = create_engine(TEST_DB_URL)
+        DBSession.configure(bind=engine)
+
+    def tearDown(self):
+        DBSession.rollback()
+
+    def test_make_new(self):
+        new_es = exam_subscription.make_new('test@email.com', 120)
+        self.assertIsNotNone(new_es.id)
+        self.assertEqual(new_es.email_address, 'test@email.com')
+        self.assertEqual(new_es.job_id, 120)
+        self.assertIsNone(new_es.time_sent)
+
+        db_es = DBSession.query(ExamSubscriptionModel)\
+             .filter(ExamSubscriptionModel.id == new_es.id)\
+             .one()
+        self.assertEqual(db_es.email_address, new_es.email_address)
+        self.assertEqual(db_es.job_id, new_es.job_id)
+        self.assertEqual(db_es.id, new_es.id)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/work4la/test/components/job_test.py
+++ b/work4la/test/components/job_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-
 from work4la.components.job import get_job_by_alias
 
 

--- a/work4la/test/util/app_test_case.py
+++ b/work4la/test/util/app_test_case.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from work4la.test.util.db import TEST_DB_URL
+
+
+class AppTestCase(unittest.TestCase):
+
+    def setUp(self):
+        settings = {
+            'sqlalchemy.url': TEST_DB_URL
+        }
+        from work4la import main
+        app = main({}, **settings)
+        from webtest import TestApp
+        self.testapp = TestApp(app)

--- a/work4la/test/util/db.py
+++ b/work4la/test/util/db.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+TEST_DB_URL = 'mysql+pymysql://w4latest:@localhost/work4la_test'

--- a/work4la/test/views/home_test.py
+++ b/work4la/test/views/home_test.py
@@ -3,6 +3,7 @@ import unittest
 
 from pyramid import testing
 
+from work4la.test.util.app_test_case import AppTestCase
 from work4la.views import home
 
 
@@ -19,13 +20,7 @@ class HomeTest(unittest.TestCase):
         self.assertEqual(home(request), {})
 
 
-class HomeFunctionalTest(unittest.TestCase):
-
-    def setUp(self):
-        from work4la import main
-        app = main({})
-        from webtest import TestApp
-        self.testapp = TestApp(app)
+class HomeFunctionalTest(AppTestCase):
 
     def test_root(self):
         res = self.testapp.get('/', status=200)

--- a/work4la/test/views/job_test.py
+++ b/work4la/test/views/job_test.py
@@ -1,18 +1,10 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from pyramid import testing
-
-from work4la.views import view_job
+from work4la.test.util.app_test_case import AppTestCase
 
 
-class JobFunctionalTest(unittest.TestCase):
-
-    def setUp(self):
-        from work4la import main
-        app = main({})
-        from webtest import TestApp
-        self.testapp = TestApp(app)
+class JobFunctionalTest(AppTestCase):
 
     def test_bad_alias(self):
         res = self.testapp.get('/job/foo', status=404)

--- a/work4la/test/views/subscribe_test.py
+++ b/work4la/test/views/subscribe_test.py
@@ -1,19 +1,11 @@
 # -*- coding: utf-8 -*-
-import json
 import unittest
 
-from pyramid import testing
-
+from work4la.test.util.app_test_case import AppTestCase
 from work4la.views import subscribe
 
 
-class SubscribeFunctionalTest(unittest.TestCase):
-
-    def setUp(self):
-        from work4la import main
-        app = main({})
-        from webtest import TestApp
-        self.testapp = TestApp(app)
+class SubscribeFunctionalTest(AppTestCase):
 
     def test_get_404s(self):
         self.testapp.get('/subscribe', status=404)


### PR DESCRIPTION
This branch sets us up with SQLAlchemy, and some other machinery that will manage transactions across the lifetime of a Pyramid web request (i.e. commit if the request completes without failure). For more info on what `transaction`, `pyramid_tm`, and Zope are, the first part of [this blog post](https://metaclassical.com/what-the-zope-transaction-manager-means-to-me-and-you/) is helpful.

Things to note:
* See the MySQL URL in development.ini. Developers have to run MySQL locally and create a `work4la` database with an `exam_subscription` table.
* Tests will use a different database so as not to mess with your local app database. URL defined in work4la/test/util/db.py. Would be nice to spin up a database every time tests are run and then dispose of it, but I don't know how much more work that is. This will work for now?
* Check out ExamSubscription. This is what we will use to store email address and job class ID when someone subscribes for notifications.
* `exam_subscription.make_new(...)` doesn't commit, because the function will be used in the context of a web request, which will automatically commit if the request is successful (via the integration with `transaction` and `pyramid_tm`).

```
============================================================================= test session starts =============================================================================
platform darwin -- Python 3.5.2, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /Users/alexchao/workspace/h4la/w4laenv/work4la, inifile: pytest.ini
plugins: cov-2.4.0
collected 13 items

work4la/test/components/exam_subscription_test.py .
work4la/test/components/job_test.py ..
work4la/test/views/home_test.py ..
work4la/test/views/job_test.py ...
work4la/test/views/subscribe_test.py .....

========================================================================== 13 passed in 1.14 seconds ==========================================================================
```